### PR TITLE
chore: remove the BOM from the package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
    "name":"net.tnrd.customdrawers",
    "version":"0.9.0",
    "displayName":"Custom Drawers",


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc7159#section-8.1

> Implementations MUST NOT add a byte order mark to the beginning of a
   JSON text.